### PR TITLE
chore: CR fixes 

### DIFF
--- a/cacheproc/cacheproc.go
+++ b/cacheproc/cacheproc.go
@@ -20,14 +20,22 @@ import (
 	"sync"
 
 	"github.com/bradfitz/go-tool-cache/cachers"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/bradfitz/go-tool-cache/wire"
+)
+
+var (
+	ErrUnknownCommand = errors.New("unknown command")
+	ErrNoOutputID     = errors.New("no outputID")
 )
 
 // Process implements the cmd/go JSON protocol over stdin & stdout via three
 // funcs that callers can optionally implement.
 type Process struct {
-	cache cachers.LocalCache
+	cache    cachers.LocalCache
+	closer   sync.Once
+	errClose error
 }
 
 func NewCacheProc(cache cachers.LocalCache) *Process {
@@ -45,8 +53,13 @@ func (p *Process) Run() error {
 	if err := p.cache.Start(); err != nil {
 		return err
 	}
+	defer func() {
+		_ = p.close()
+	}()
 	caps := []wire.Cmd{"get", "put", "close"}
-	je.Encode(&wire.Response{KnownCommands: caps})
+	if err := je.Encode(&wire.Response{KnownCommands: caps}); err != nil {
+		return err
+	}
 	if err := bw.Flush(); err != nil {
 		return err
 	}
@@ -56,6 +69,7 @@ func (p *Process) Run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	wg, ctx := errgroup.WithContext(ctx)
 	for {
 		var req wire.Request
 		if err := jd.Decode(&req); err != nil {
@@ -76,26 +90,28 @@ func (p *Process) Run() error {
 			}
 			req.Body = bytes.NewReader(bodyb)
 		}
-		go func() {
+		wg.Go(func() error {
 			res := &wire.Response{ID: req.ID}
-			ctx := ctx // TODO: include req ID as a context.Value for tracing?
+			ctx := context.WithValue(ctx, "requestID", &req)
 			if err := p.handleRequest(ctx, &req, res); err != nil {
 				res.Err = err.Error()
 			}
 			wmu.Lock()
 			defer wmu.Unlock()
-			je.Encode(res)
-			bw.Flush()
-		}()
+			_ = je.Encode(res)
+			_ = bw.Flush()
+			return nil
+		})
 	}
+	return wg.Wait()
 }
 
 func (p *Process) handleRequest(ctx context.Context, req *wire.Request, res *wire.Response) error {
 	switch req.Command {
 	default:
-		return errors.New("unknown command")
+		return ErrUnknownCommand
 	case "close":
-		return p.cache.Close()
+		return p.close()
 	case "get":
 		return p.handleGet(ctx, req, res)
 	case "put":
@@ -113,7 +129,7 @@ func (p *Process) handleGet(ctx context.Context, req *wire.Request, res *wire.Re
 		return nil
 	}
 	if outputID == "" {
-		return errors.New("no outputID")
+		return ErrNoOutputID
 	}
 	res.OutputID, err = hex.DecodeString(outputID)
 	if err != nil {
@@ -160,4 +176,14 @@ func (p *Process) handlePut(ctx context.Context, req *wire.Request, res *wire.Re
 	}
 	res.DiskPath = diskPath
 	return nil
+}
+
+func (p *Process) close() error {
+	p.closer.Do(func() {
+		p.errClose = p.cache.Close()
+		if p.errClose != nil {
+			log.Printf("cache stop failed: %v", p.errClose)
+		}
+	})
+	return p.errClose
 }

--- a/cachers/cache.go
+++ b/cachers/cache.go
@@ -7,7 +7,7 @@ import (
 
 // Cache is the interface implemented by all caches.
 type Cache interface {
-	Start() error
+	Start(ctx context.Context) error
 	Close() error
 	Kind() string
 }

--- a/cachers/combined.go
+++ b/cachers/combined.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // CombinedCache is a LocalCache that wraps a LocalCache and a RemoteCache.
@@ -48,6 +50,7 @@ func (l *CombinedCache) Start(ctx context.Context) error {
 	}
 	err = l.remoteCache.Start(ctx)
 	if err != nil {
+		_ = l.localCache.Close()
 		return fmt.Errorf("remote cache start failed: %w", err)
 	}
 	l.putsMetrics.Start(ctx)
@@ -55,8 +58,8 @@ func (l *CombinedCache) Start(ctx context.Context) error {
 	return nil
 }
 
-func (l *CombinedCache) Get(ctx context.Context, actionID string) (outputID, diskPath string, err error) {
-	outputID, diskPath, err = l.localCache.Get(ctx, actionID)
+func (l *CombinedCache) Get(ctx context.Context, actionID string) (string, string, error) {
+	outputID, diskPath, err := l.localCache.Get(ctx, actionID)
 	if err == nil && outputID != "" {
 		return outputID, diskPath, nil
 	}
@@ -77,22 +80,17 @@ func (l *CombinedCache) Get(ctx context.Context, actionID string) (outputID, dis
 	return outputID, diskPath, nil
 }
 
-func (l *CombinedCache) Put(ctx context.Context, actionID, outputID string, size int64, body io.Reader) (string, error) {
+func (l *CombinedCache) Put(ctx context.Context, actionID, outputID string, size int64, body io.Reader) (diskPath string, err error) {
 	pr, pw := io.Pipe()
-	diskPathCh := make(chan string, 1)
-	errCh := make(chan error, 1)
-	go func() {
+	wg, _ := errgroup.WithContext(ctx)
+	wg.Go(func() error {
 		var putBody io.Reader = pr
 		if size == 0 {
 			putBody = bytes.NewReader(nil)
 		}
-		diskPath, err := l.localCache.Put(ctx, actionID, outputID, size, putBody)
-		if err != nil {
-			errCh <- err
-		} else {
-			diskPathCh <- diskPath
-		}
-	}()
+		diskPath, err = l.localCache.Put(ctx, actionID, outputID, size, putBody)
+		return err
+	})
 
 	var putBody io.Reader
 	if size == 0 {
@@ -110,13 +108,12 @@ func (l *CombinedCache) Put(ctx context.Context, actionID, outputID string, size
 		return "", e
 	})
 	pw.Close()
-	select {
-	case err := <-errCh:
+	if err := wg.Wait(); err != nil {
 		log.Printf("[%s]\terror: %v", l.localCache.Kind(), err)
 		return "", err
-	case diskPath := <-diskPathCh:
-		return diskPath, nil
 	}
+	return diskPath, nil
+
 }
 
 func (l *CombinedCache) Close() error {

--- a/cachers/combined.go
+++ b/cachers/combined.go
@@ -88,8 +88,9 @@ func (l *CombinedCache) Put(ctx context.Context, actionID, outputID string, size
 		if size == 0 {
 			putBody = bytes.NewReader(nil)
 		}
-		diskPath, err = l.localCache.Put(ctx, actionID, outputID, size, putBody)
-		return err
+		var err2 error
+		diskPath, err2 = l.localCache.Put(ctx, actionID, outputID, size, putBody)
+		return err2
 	})
 
 	var putBody io.Reader

--- a/cachers/counts.go
+++ b/cachers/counts.go
@@ -41,8 +41,8 @@ func (r *RemoteCacheWithCounts) Kind() string {
 	return r.cache.Kind()
 }
 
-func (r *RemoteCacheWithCounts) Start() error {
-	return r.cache.Start()
+func (r *RemoteCacheWithCounts) Start(ctx context.Context) error {
+	return r.cache.Start(ctx)
 }
 
 func (r *RemoteCacheWithCounts) Close() error {
@@ -75,8 +75,8 @@ func (r *RemoteCacheWithCounts) Put(ctx context.Context, actionID, outputID stri
 	return
 }
 
-func (l *LocalCacheWithCounts) Start() error {
-	return l.cache.Start()
+func (l *LocalCacheWithCounts) Start(ctx context.Context) error {
+	return l.cache.Start(ctx)
 }
 
 func (l *LocalCacheWithCounts) Close() error {

--- a/cachers/disk.go
+++ b/cachers/disk.go
@@ -113,16 +113,13 @@ func writeTempFile(dest string, r io.Reader) (string, int64, error) {
 	}
 	fileName := tf.Name()
 	defer func() {
+		_ = tf.Close()
 		if err != nil {
-			_ = tf.Close()
 			_ = os.Remove(fileName)
 		}
 	}()
 	size, err := io.Copy(tf, r)
 	if err != nil {
-		return "", 0, err
-	}
-	if err := tf.Close(); err != nil {
 		return "", 0, err
 	}
 	return fileName, size, nil
@@ -133,8 +130,10 @@ func writeAtomic(dest string, r io.Reader) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if err := os.Rename(tempFile, dest); err != nil {
+	defer func() {
 		_ = os.Remove(tempFile)
+	}()
+	if err := os.Rename(tempFile, dest); err != nil {
 		return 0, err
 	}
 	return size, nil

--- a/cachers/disk.go
+++ b/cachers/disk.go
@@ -40,7 +40,7 @@ func NewSimpleDiskCache(verbose bool, dir string) *SimpleDiskCache {
 
 var _ LocalCache = &SimpleDiskCache{}
 
-func (dc *SimpleDiskCache) Start() error {
+func (dc *SimpleDiskCache) Start(ctx context.Context) error {
 	log.Printf("[%s]\tlocal cache in  %s", dc.Kind(), dc.dir)
 	return nil
 }

--- a/cachers/disk.go
+++ b/cachers/disk.go
@@ -131,9 +131,11 @@ func writeAtomic(dest string, r io.Reader) (int64, error) {
 		return 0, err
 	}
 	defer func() {
-		_ = os.Remove(tempFile)
+		if err != nil {
+			_ = os.Remove(tempFile)
+		}
 	}()
-	if err := os.Rename(tempFile, dest); err != nil {
+	if err = os.Rename(tempFile, dest); err != nil {
 		return 0, err
 	}
 	return size, nil

--- a/cachers/http.go
+++ b/cachers/http.go
@@ -36,7 +36,7 @@ func NewHttpCache(baseURL string, verbose bool) *HTTPCache {
 	}
 }
 
-func (c *HTTPCache) Start() error {
+func (c *HTTPCache) Start(ctx context.Context) error {
 	log.Printf("[%s]\tconfigured to %s", c.Kind(), c.baseURL)
 	return nil
 }

--- a/cachers/s3.go
+++ b/cachers/s3.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"runtime"
 
 	"github.com/aws/smithy-go"
@@ -94,11 +95,17 @@ func (s *S3Cache) Close() error {
 }
 
 func NewS3Cache(client s3Client, bucketName string, cacheKey string, verbose bool) *S3Cache {
-	// get current architecture
-	arc := runtime.GOARCH
-	// get current operating system
-	os := runtime.GOOS
-	prefix := fmt.Sprintf("cache/%s/%s/%s", cacheKey, arc, os)
+	// get target architecture
+	goarch := os.Getenv("GOARCH")
+	if goarch == "" {
+		goarch = runtime.GOARCH
+	}
+	// get target operating system
+	goos := os.Getenv("GOOS")
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	prefix := fmt.Sprintf("cache/%s/%s/%s", cacheKey, goarch, goos)
 	cache := &S3Cache{
 		s3Client: client,
 		bucket:   bucketName,

--- a/cachers/s3.go
+++ b/cachers/s3.go
@@ -39,7 +39,7 @@ func (s *S3Cache) Kind() string {
 	return "s3"
 }
 
-func (s *S3Cache) Start() error {
+func (s *S3Cache) Start(ctx context.Context) error {
 	log.Printf("[%s]\tconfigured to s3://%s/%s", s.Kind(), s.bucket, s.prefix)
 	return nil
 }

--- a/cachers/timekeeper.go
+++ b/cachers/timekeeper.go
@@ -26,7 +26,7 @@ type metric struct {
 
 func newTimeKeeper() *timeKeeper {
 	return &timeKeeper{
-		metricsChan: make(chan metric, 100),
+		metricsChan: make(chan metric, 1024),
 	}
 }
 

--- a/cachers/timekeeper.go
+++ b/cachers/timekeeper.go
@@ -1,9 +1,11 @@
 package cachers
 
 import (
+	"context"
 	"fmt"
-	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // timeKeeper can be used to measure time and bytes of operations
@@ -13,7 +15,7 @@ type timeKeeper struct {
 	TotalBytes        int64
 	AvgBytesPerSecond float64
 	metricsChan       chan metric
-	wg                sync.WaitGroup
+	wg                *errgroup.Group
 }
 
 // metric holds data of single op event: size in bytes and duration
@@ -28,22 +30,22 @@ func newTimeKeeper() *timeKeeper {
 	}
 }
 
-func (c *timeKeeper) Start() {
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
+func (c *timeKeeper) Start(ctx context.Context) {
+	c.wg, _ = errgroup.WithContext(ctx)
+	c.wg.Go(func() error {
 		for m := range c.metricsChan {
 			c.TotalBytes += m.bytes
 			speed := float64(m.bytes) / m.duration.Seconds()
 			c.AvgBytesPerSecond = newAverage(c.AvgBytesPerSecond, c.Count, speed)
 			c.Count++
 		}
-	}()
+		return nil
+	})
 }
 
-func (c *timeKeeper) Stop() {
+func (c *timeKeeper) Stop() error {
 	close(c.metricsChan)
-	c.wg.Wait()
+	return c.wg.Wait()
 }
 
 func (c *timeKeeper) Summary() string {

--- a/cmd/go-cacher-server/cacher-server.go
+++ b/cmd/go-cacher-server/cacher-server.go
@@ -75,7 +75,9 @@ type server struct {
 }
 
 func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	time.Sleep(s.latency)
+	if s.latency > 0 {
+		time.Sleep(s.latency)
+	}
 	if s.verbose {
 		log.Printf("%s %s", r.Method, r.RequestURI)
 	}

--- a/cmd/go-cacher/cacher.go
+++ b/cmd/go-cacher/cacher.go
@@ -143,8 +143,8 @@ func main() {
 
 	var localCache cachers.LocalCache = cachers.NewSimpleDiskCache(*verbose, dir)
 	ctx, cancel := context.WithCancel(context.Background())
-	proc := cacheproc.NewCacheProc(getCache(ctx, localCache, *verbose))
 	defer cancel()
+	proc := cacheproc.NewCacheProc(getCache(ctx, localCache, *verbose))
 	if err := proc.Run(ctx); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/go-cacher/cacher.go
+++ b/cmd/go-cacher/cacher.go
@@ -46,7 +46,7 @@ var (
 	verbose = flag.Bool("verbose", false, "be verbose")
 )
 
-func getAwsConfigFromEnv() (*aws.Config, error) {
+func getAwsConfigFromEnv(ctx context.Context) (*aws.Config, error) {
 	// read from env
 	awsRegion := os.Getenv(envVarS3CacheRegion)
 	if awsRegion == "" {
@@ -55,7 +55,7 @@ func getAwsConfigFromEnv() (*aws.Config, error) {
 	accessKey := os.Getenv(envVarS3AwsAccessKey)
 	secretAccessKey := os.Getenv(envVarS3AwsSecretAccessKey)
 	if accessKey != "" && secretAccessKey != "" {
-		cfg, err := config.LoadDefaultConfig(context.TODO(),
+		cfg, err := config.LoadDefaultConfig(ctx,
 			config.WithRegion(awsRegion),
 			config.WithCredentialsProvider(credentials.StaticCredentialsProvider{
 				Value: aws.Credentials{
@@ -79,8 +79,8 @@ func getAwsConfigFromEnv() (*aws.Config, error) {
 	return nil, nil
 }
 
-func maybeS3Cache() (cachers.RemoteCache, error) {
-	awsConfig, err := getAwsConfigFromEnv()
+func maybeS3Cache(ctx context.Context) (cachers.RemoteCache, error) {
+	awsConfig, err := getAwsConfigFromEnv(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +98,8 @@ func maybeS3Cache() (cachers.RemoteCache, error) {
 	return s3Cache, nil
 }
 
-func getCache(local cachers.LocalCache, verbose bool) cachers.LocalCache {
-	remote, err := maybeS3Cache()
+func getCache(ctx context.Context, local cachers.LocalCache, verbose bool) cachers.LocalCache {
+	remote, err := maybeS3Cache(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -140,9 +140,12 @@ func main() {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		log.Fatal(err)
 	}
+
 	var localCache cachers.LocalCache = cachers.NewSimpleDiskCache(*verbose, dir)
-	proc := cacheproc.NewCacheProc(getCache(localCache, *verbose))
-	if err := proc.Run(); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	proc := cacheproc.NewCacheProc(getCache(ctx, localCache, *verbose))
+	defer cancel()
+	if err := proc.Run(ctx); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/go-cacher/cacher.go
+++ b/cmd/go-cacher/cacher.go
@@ -49,7 +49,7 @@ var (
 func getAwsConfigFromEnv() (*aws.Config, error) {
 	// read from env
 	awsRegion := os.Getenv(envVarS3CacheRegion)
-	if awsRegion != "" {
+	if awsRegion == "" {
 		return nil, nil
 	}
 	accessKey := os.Getenv(envVarS3AwsAccessKey)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.15.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.42.1
 	github.com/aws/smithy-go v1.16.0
+	golang.org/x/sync v0.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -37,3 +37,5 @@ github.com/aws/smithy-go v1.16.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=


### PR DESCRIPTION
After @gmwiz review on https://github.com/or-shachar/go-tool-cache/pull/5
1. Using errgroup as wait group
2. Organized contexts
3. Better errors
4. Fixed a bug introduced in previous #6 

Did not group imports - I'm using default IDE formatter