### PR TITLE
Add `OutputID` for compatibility with Go1.24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build with Go ${{ matrix.go }} 
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.23', '1.24.0-rc.1' ]
     steps:
       - uses: actions/checkout@v4
 

--- a/cmd/go-cacher-server/cacher-server.go
+++ b/cmd/go-cacher-server/cacher-server.go
@@ -189,16 +189,16 @@ func (s *server) handlePut(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func OutputFilename(dir, objectID string) string {
-	if len(objectID) < 4 || len(objectID) > 1000 {
+func OutputFilename(dir, outputID string) string {
+	if len(outputID) < 4 || len(outputID) > 1000 {
 		return ""
 	}
-	for i := range objectID {
-		b := objectID[i]
+	for i := range outputID {
+		b := outputID[i]
 		if b >= '0' && b <= '9' || b >= 'a' && b <= 'f' {
 			continue
 		}
 		return ""
 	}
-	return filepath.Join(dir, fmt.Sprintf("o-%s", objectID))
+	return filepath.Join(dir, fmt.Sprintf("o-%s", outputID))
 }

--- a/wire/wire.go
+++ b/wire/wire.go
@@ -38,8 +38,12 @@ type Request struct {
 	// ActionID is non-nil for get and puts.
 	ActionID []byte `json:",omitempty"` // or nil if not used
 
-	// ObjectID is set for Type "put" and "output-file".
-	ObjectID []byte `json:",omitempty"` // or nil if not used
+	// OutputID is set for Type "put" and "output-file".
+	OutputID []byte `json:",omitempty"` // or nil if not used
+
+	// ObjectID is the name of `OutputID` before Go1.24, it will be removed in Go1.25.
+	// It's used for backward compatibility.
+	ObjectID []byte `json:",omitempty"`
 
 	// Body is the body for "put" requests. It's sent after the JSON object
 	// as a base64-encoded JSON string when BodySize is non-zero.
@@ -81,8 +85,8 @@ type Response struct {
 	Size      int64  `json:",omitempty"`
 	TimeNanos int64  `json:",omitempty"` // TODO(bradfitz): document
 
-	// DiskPath is the absolute path on disk of the ObjectID corresponding
+	// DiskPath is the absolute path on disk of the OutputID corresponding
 	// a "get" request's ActionID (on cache hit) or a "put" request's
-	// provided ObjectID.
+	// provided OutputID.
 	DiskPath string `json:",omitempty"`
 }


### PR DESCRIPTION
In Go1.24rc1, the ObjectID field was renamed to OutputID, see https://github.com/golang/go/commit/83a7626687c790b3770592794ba12e06fbc87a35