### PR TITLE
Log only if verbose

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build with Go ${{ matrix.go }} 
     strategy:
       matrix:
-        go: [ '1.23', '1.24.0-rc.1' ]
+        go: [ '1.23', '1.24' ]
     steps:
       - uses: actions/checkout@v4
 

--- a/cachers/disk.go
+++ b/cachers/disk.go
@@ -41,7 +41,9 @@ func NewSimpleDiskCache(verbose bool, dir string) *SimpleDiskCache {
 var _ LocalCache = &SimpleDiskCache{}
 
 func (dc *SimpleDiskCache) Start(context.Context) error {
-	log.Printf("[%s]\tlocal cache in  %s", dc.Kind(), dc.dir)
+	if dc.verbose {
+		log.Printf("[%s]\tlocal cache in  %s", dc.Kind(), dc.dir)
+	}
 	return os.MkdirAll(dc.dir, 0755)
 }
 

--- a/cachers/http.go
+++ b/cachers/http.go
@@ -37,7 +37,9 @@ func NewHttpCache(baseURL string, verbose bool) *HTTPCache {
 }
 
 func (c *HTTPCache) Start(context.Context) error {
-	log.Printf("[%s]\tconfigured to %s", c.Kind(), c.baseURL)
+	if c.verbose {
+		log.Printf("[%s]\tconfigured to %s", c.Kind(), c.baseURL)
+	}
 	return nil
 }
 

--- a/cachers/s3.go
+++ b/cachers/s3.go
@@ -42,7 +42,9 @@ func (s *S3Cache) Kind() string {
 }
 
 func (s *S3Cache) Start(context.Context) error {
-	log.Printf("[%s]\tconfigured to s3://%s/%s", s.Kind(), s.bucket, s.prefix)
+	if s.verbose {
+		log.Printf("[%s]\tconfigured to s3://%s/%s", s.Kind(), s.bucket, s.prefix)
+	}
 	return nil
 }
 


### PR DESCRIPTION
- Log to stderr only if verbose, otherwise GOCACHEPROG messes up w/ go test and its wrappers (a-la gotestsum) to think there was an error in the run, as stderr is dirtied