### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/or-shachar/go-tool-cache/security/code-scanning/3](https://github.com/or-shachar/go-tool-cache/security/code-scanning/3)

To fix this problem, an explicit `permissions` block should be added specifying the least privilege required for the job. In this workflow, no steps perform repository write actions, so `contents: read` is adequate. The `permissions` block can be added either at the top-level of the workflow (applying to all jobs) or inside the `build` job. Adding it at the top ensures all jobs (present or future) default to least privilege unless overridden. The fix involves inserting the following block near the top of the workflow, after the workflow `name` and before `on`, or inside the relevant job definition before `runs-on`. Since this workflow includes only one job and follows GitHub recommendations, the top-level placement is preferred.

- File to edit: `.github/workflows/go.yml`
- Region to change: After the `name:` block and before the `on:` block.
- Edit required: Insert `permissions:\n  contents: read`

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
