### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   goreleaser:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/or-shachar/go-tool-cache/security/code-scanning/1](https://github.com/or-shachar/go-tool-cache/security/code-scanning/1)

To fix the problem, an explicit `permissions` block should be added. As the release process with GoReleaser requires pushing tags, creating releases, and uploading assets, the minimum necessary permission is `contents: write`. This permission allows the job to read and update repository contents as needed for a release. The best place to add the block is directly under the `goreleaser` job, ensuring that only this job receives the required write permissions and that other jobs (if any are added) do not inherit unnecessary privileges. If you wanted to restrict privilege further and other jobs only require reading, you could add a root `permissions: contents: read` block and override it for this job, but for now, just adding it in the `goreleaser` job is both minimal and clear.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
